### PR TITLE
feat: Initial build/release config

### DIFF
--- a/.github/cspell.yaml
+++ b/.github/cspell.yaml
@@ -1,0 +1,28 @@
+---
+# cSpell Settings
+
+version: "0.2"
+
+# flagWords - list of words to be always considered incorrect
+# This is useful for offensive words and common spelling errors.
+# For example "hte" should be "the"
+flagWords:
+  - hte
+
+language: en
+
+# words - list of words to be always considered correct: an Allowlist per-se
+words:
+  # Synology Architecture name
+  - Broadwell
+  - Denverton
+  - Grantley
+  - NETFILTER
+  - NFSD
+  - Purley
+  - Syno
+  - allanc
+  - chickenandpork
+  - kernelconfig
+  - kmods
+  - netfilter

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+---
+name: CI
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - denverton
+          # - geminilake
+    name: build ${{ matrix.arch }} kernel modules
+    steps:
+      - name: Clone Repo
+        uses: actions/checkout@v4
+      - name: Kernel configure and build
+        uses: chickenandpork/synology-docker-kernel-action@master
+        id: build
+        with:
+          artifacts: net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko
+          dsm-version: '7.2'
+          module-deactivate: CONFIG_NFSD CONFIG_NFS_FS
+          module-modularize: CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT
+          package-arch: ${{ matrix.arch }}
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          path: ${{ github.workspace }}/${{ steps.build.outputs.archive }}
+          retention-days: 7
+      - name: Debug Info
+        run: |
+          ls -al .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+---
+name: Release
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+      matrix:
+        arch:
+          - denverton
+          # - geminilake
+    name: build ${{ matrix.arch }} kernel modules
+    steps:
+      - name: Clone Repo
+        uses: actions/checkout@v4
+      - name: Kernel configure and build
+        uses: chickenandpork/synology-docker-kernel-action@master
+        id: build
+        with:
+          artifacts: net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko
+          dsm-version: '7.2'
+          module-deactivate: CONFIG_NFSD CONFIG_NFS_FS
+          module-modularize: CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT
+          package-arch: ${{ matrix.arch }}
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          path: ${{ github.workspace }}/${{ steps.build.outputs.archive }}
+          retention-days: 7
+
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    needs: [build]
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        # Settings -> Actions -> General -> Workflow Permissions
+        # - select "Read repo contents", and
+        # - enable "Allow Github Actions to create and approve pull requests"
+        id: release
+        with:
+          release-type: simple
+      - name: Clone Repo
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        id: download
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Upload Release Artifacts
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ls -al
+          echo download is ${{ steps.download.outputs.download-path }}
+          gh release upload ${{ steps.release.outputs.tag_name }} [a-z]*-[0-9].*.txz  # ie denverton-7.2.txz

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+# To install the dependencies for this file:
+# 1) pip install pre-commit
+#   (really, "sudo python3 -m pip install pre-commit")
+#   (really, I've been carrying this boilerplate for years, but now it's all python3?)
+#
+# 2) pre-commit install --allow-missing-config
+#
+# yamllint checks this .pre-commit-config file as well
+---
+repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: [
+          '-d',
+          '{extends: default, rules: {line-length: {max: 120}}}'
+        ]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.2
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.7.0
+    hooks:
+      - id: cspell
+        # a local allowlist of dictionary words in .github/cspell.yaml.  This can get comical --
+        # adding new words in every PR -- but the cost/benefit balance may avoid some embarassing
+        # typos
+        args: ['--config', '.github/cspell.yaml']
+        types: [file, markdown]


### PR DESCRIPTION
Initial build / release config: Starting with denverton-7.2, a matrix configures the architectures that are built.  Some duplication in the `ci.yaml` vs `release.yaml`, but I'll see if I can combine those (such as https://stackoverflow.com/a/73060319) eventually.  Currently, I just use some branch selection to ensure they don't both run on a release action.