### PR TITLE
chore: pin action to hash so that updates merge via visible PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Clone Repo
         uses: actions/checkout@v4
       - name: Kernel configure and build
-        uses: chickenandpork/synology-docker-kernel-action@master
+        uses: chickenandpork/synology-docker-kernel-action@0adcdcfa44df10f3974b7d7c1267ace4ec345b47
         id: build
         with:
           artifacts: net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Clone Repo
         uses: actions/checkout@v4
       - name: Kernel configure and build
-        uses: chickenandpork/synology-docker-kernel-action@master
+        uses: chickenandpork/synology-docker-kernel-action@0adcdcfa44df10f3974b7d7c1267ace4ec345b47
         id: build
         with:
           artifacts: net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko


### PR DESCRIPTION
Pin the synology-docker-kernel-action so that when there's an update, it shows as a visible PR (leaning on Renovate for that)