### PR TITLE
feat: deliverable now include kernel config (from PR #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # synology-kmods-netfilter-iptables
 The repository uses GitHub actions to cross-build linux kernel modules for Synology NAS
+
+The underlying action now adds .config to the resulting package


### PR DESCRIPTION
#5 merged but did not mark that the deliverable in the newer version of the `synology-docker-kernel-action` now includes `.config`, so I'm pushing this trivial doc changes a feature to mark that the results have improved.